### PR TITLE
add uploading CSV to DynamoDB with email notifications

### DIFF
--- a/import_service/lib/lambdas/importFileParserLambda.ts
+++ b/import_service/lib/lambdas/importFileParserLambda.ts
@@ -1,15 +1,25 @@
-// lambda/importFileParser.ts
 import { S3Handler } from 'aws-lambda';
-import { S3 } from 'aws-sdk';
+import { S3, SQS } from 'aws-sdk';
 
 const csvParser = require('/opt/nodejs/csv-parser-utils');
 
 const BUCKET_NAME = process.env.BUCKET_NAME!;
+const SQS_QUEUE_NAME  = process.env.SQS_QUEUE_NAME!;
 const s3 = new S3();
+const sqs = new SQS();
+
+let cachedQueueUrl: string | undefined;
+const getQueueUrl = async (): Promise<string> => {
+  if (cachedQueueUrl) return cachedQueueUrl;
+  const { QueueUrl } = await sqs.getQueueUrl({ QueueName: SQS_QUEUE_NAME }).promise();
+  cachedQueueUrl = QueueUrl!
+  return cachedQueueUrl;
+}
 
 export const handler: S3Handler = async (event) => {
-  console.log('Event received:', event);
-  
+  console.log('Incoming event:', event);
+  const queueUrl = await getQueueUrl();
+
   for (const record of event.Records) {
     const key = record.s3.object.key;
     console.log(`Processing file: ${key}`);
@@ -22,14 +32,22 @@ export const handler: S3Handler = async (event) => {
     const s3Stream = s3.getObject(params).createReadStream();
 
     await new Promise<void>((resolve, reject) => {
+      const sqsPromises: Promise<any>[] = [];
+
       s3Stream
         .pipe(csvParser())
         .on('data', (data: any) => {
-          console.log('Parsed record:', data);
+          const sqsParams = {
+            QueueUrl: queueUrl,
+            MessageBody: JSON.stringify(data),
+          };
+          sqsPromises.push(sqs.sendMessage(sqsParams).promise());
         })
         .on('end', async () => {
-          const newKey = key.replace('uploaded/', 'parsed/');
           try {
+            await Promise.all(sqsPromises);
+
+            const newKey = key.replace('uploaded/', 'parsed/');
             await s3.copyObject({
               Bucket: BUCKET_NAME,
               CopySource: `${BUCKET_NAME}/${key}`,
@@ -44,7 +62,7 @@ export const handler: S3Handler = async (event) => {
             console.log(`File moved to ${newKey}`);
             resolve();
           } catch (error) {
-            console.error('Error moving file:', error);
+            console.error('Error processing CSV stream promises:', error);
             reject(error);
           }
         })

--- a/product_service/lib/lambdas/catalogBatchProcessLambda.ts
+++ b/product_service/lib/lambdas/catalogBatchProcessLambda.ts
@@ -1,0 +1,86 @@
+import {
+  DynamoDBClient,
+  TransactWriteItemsCommand,
+} from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { v4 as uuidv4 } from "/opt/nodejs/uuid-utils";
+import { marshall } from "@aws-sdk/util-dynamodb";
+import { SNSClient, PublishCommand } from "@aws-sdk/client-sns";
+
+const client = new DynamoDBClient({ region: "eu-central-1" });
+const documentClient = DynamoDBDocumentClient.from(client);
+const snsClient = new SNSClient({ region: "eu-central-1" });
+
+export const handler = async (event: any) => {
+  console.log("Incoming event:", event);
+  const productTable = process.env.PRODUCT_TABLE!;
+  const stocksTable = process.env.STOCKS_TABLE!;
+  const topicArn = process.env.CREATE_PRODUCT_TOPIC_ARN!;
+
+  for (const record of event.Records) {
+    try {
+      const data = JSON.parse(record.body);
+      const id = uuidv4();
+
+      const productItem = {
+        id,
+        title: data.title,
+        description: data.description,
+        price: Number(data.price),
+      };
+
+      const stockItem = {
+        product_id: id,
+        count: data.count !== undefined ? Number(data.count) : 0,
+      };
+
+      const params = {
+        TransactItems: [
+          {
+            Put: {
+              TableName: productTable,
+              Item: marshall(productItem),
+            },
+          },
+          {
+            Put: {
+              TableName: stocksTable,
+              Item: marshall(stockItem),
+            },
+          },
+        ],
+      };
+
+      const command = new TransactWriteItemsCommand(params);
+      await documentClient.send(command);
+
+      console.log(
+        "Inserted product and stock into DynamoDB:",
+        productItem,
+        stockItem
+      );
+
+      const messageAttributes = {
+        price: {
+          DataType: "Number",
+          StringValue: String(productItem.price),
+        },
+      };
+
+      const publishCommand = new PublishCommand({
+        TopicArn: topicArn,
+        Message: JSON.stringify({
+          message: "Product created",
+          product: productItem,
+        }),
+        MessageAttributes: messageAttributes,
+      });
+
+      await snsClient.send(publishCommand);
+      console.log("Published product creation event to SNS:", topicArn);
+      
+    } catch (error) {
+      console.error("Error processing record:", record, error);
+    }
+  }
+};

--- a/product_service/lib/product-service-stack.ts
+++ b/product_service/lib/product-service-stack.ts
@@ -1,121 +1,170 @@
-import * as cdk from 'aws-cdk-lib';
-import * as iam from 'aws-cdk-lib/aws-iam';
-import { LambdaIntegration, LambdaRestApi, Cors } from 'aws-cdk-lib/aws-apigateway';
-import { Runtime, LayerVersion, Code } from 'aws-cdk-lib/aws-lambda';
-import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
-import { Construct } from 'constructs';
-import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+  import * as cdk from 'aws-cdk-lib';
+  import * as iam from 'aws-cdk-lib/aws-iam';
+  import { LambdaIntegration, LambdaRestApi, Cors } from 'aws-cdk-lib/aws-apigateway';
+  import { Runtime, LayerVersion, Code } from 'aws-cdk-lib/aws-lambda';
+  import { Queue } from 'aws-cdk-lib/aws-sqs';
+  import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
+  import { Topic, SubscriptionFilter } from 'aws-cdk-lib/aws-sns';
+  import { EmailSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
+  import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+  import { Construct } from 'constructs';
+  import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 
-export class ProductServiceStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
-    super(scope, id, props);
+  export class ProductServiceStack extends cdk.Stack {
+    constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+      super(scope, id, props);
 
-    const productTable = dynamodb.Table.fromTableName(
-      this,
-      'ProductTable',
-      'products'
-    );
+      const productTable = dynamodb.Table.fromTableName(
+        this,
+        'ProductTable',
+        'products'
+      );
 
-    const stockTable = dynamodb.Table.fromTableName(
-      this,
-      'StockTable',
-      'stocks'
-    )
+      const stockTable = dynamodb.Table.fromTableName(
+        this,
+        'StockTable',
+        'stocks'
+      )
 
-    const readLambdaRole = new iam.Role(this, 'ReadLambdaExecutionRole', {
-      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
-      managedPolicies: [
-        iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole')
-      ]
-    })
+      const catalogItemsQueue = new Queue(this, 'catalogItemsQueue', {
+        queueName: 'catalogItemsQueue'
+      });
 
-    readLambdaRole.addToPolicy(new iam.PolicyStatement({
-      actions: ['dynamodb:GetItem', 'dynamodb:Query', 'dynamodb:Scan', 'dynamodb:BatchGetItem'],
-      resources: [productTable.tableArn, stockTable.tableArn],
-    }))
+      const createProductTopic = new Topic(this, 'CreateProductTopic', {
+        topicName: 'createProductTopic',
+      });
 
-    const writeLambdaRole = new iam.Role(this, 'WriteLambdaExecutionRole', {
-      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
-      managedPolicies: [
-         iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
-      ],
-    });
+      createProductTopic.addSubscription(
+        new EmailSubscription('citrasds@gmail.com')
+      );
 
-    writeLambdaRole.addToPolicy(new iam.PolicyStatement({
-      actions: [
-        'dynamodb:PutItem',
-        'dynamodb:UpdateItem',
-        'dynamodb:DeleteItem',
-        'dynamodb:TransactWriteItems'
-      ],
-      resources: [productTable.tableArn, stockTable.tableArn],
-    }));
+      createProductTopic.addSubscription(
+        new EmailSubscription('irakli.dsd@gmail.com', {
+          filterPolicy: {
+            price: SubscriptionFilter.numericFilter({
+              greaterThanOrEqualTo: 10000
+            })
+          }
+        })
+      )
 
-    const uuidLayer = new LayerVersion(this, 'uuid-layer', {
-      compatibleRuntimes: [
-        Runtime.NODEJS_LATEST
-      ],
-      code: Code.fromAsset('src/layers/uuid-utils'),
-      description: 'Uses a 3rd party library called uuid',
-    });
+      const readLambdaRole = new iam.Role(this, 'ReadLambdaExecutionRole', {
+        assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+        managedPolicies: [
+          iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole')
+        ]
+      })
 
-    const createProductLambda = new NodejsFunction(this, 'createProductLambda', {
-      entry: 'lib/lambdas/createProductLambda.ts',
-      handler: 'handler',
-      runtime: Runtime.NODEJS_LATEST,
-      role: writeLambdaRole,
-      bundling: {
-        minify: false,
-        externalModules: ['aws-cdk', 'uuid']
-      },
-      environment: {
-        PRODUCT_TABLE: productTable.tableName,
-        STOCKS_TABLE: stockTable.tableName,
-      },
-      layers: [uuidLayer]
-    });
+      readLambdaRole.addToPolicy(new iam.PolicyStatement({
+        actions: ['dynamodb:GetItem', 'dynamodb:Query', 'dynamodb:Scan', 'dynamodb:BatchGetItem'],
+        resources: [productTable.tableArn, stockTable.tableArn],
+      }))
 
-    const getProductListLambda = new NodejsFunction(
-      this,
-      "getProductListLambda",
-      {
-        entry: "lib/lambdas/getProductListLambda.ts",
-        handler: "handler",
+      const writeLambdaRole = new iam.Role(this, 'WriteLambdaExecutionRole', {
+        assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+        managedPolicies: [
+          iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
+        ],
+      });
+
+      writeLambdaRole.addToPolicy(new iam.PolicyStatement({
+        actions: [
+          'dynamodb:PutItem',
+          'dynamodb:UpdateItem',
+          'dynamodb:DeleteItem',
+          'dynamodb:TransactWriteItems'
+        ],
+        resources: [productTable.tableArn, stockTable.tableArn],
+      }));
+
+      const uuidLayer = new LayerVersion(this, 'uuid-layer', {
+        compatibleRuntimes: [
+          Runtime.NODEJS_LATEST
+        ],
+        code: Code.fromAsset('src/layers/uuid-utils'),
+        description: 'Uses a 3rd party library called uuid',
+      });
+
+      const createProductLambda = new NodejsFunction(this, 'createProductLambda', {
+        entry: 'lib/lambdas/createProductLambda.ts',
+        handler: 'handler',
+        runtime: Runtime.NODEJS_LATEST,
+        role: writeLambdaRole,
+        bundling: {
+          minify: false,
+          externalModules: ['aws-cdk', 'uuid']
+        },
+        environment: {
+          PRODUCT_TABLE: productTable.tableName,
+          STOCKS_TABLE: stockTable.tableName,
+        },
+        layers: [uuidLayer]
+      });
+
+      const getProductListLambda = new NodejsFunction(
+        this,
+        "getProductListLambda",
+        {
+          entry: "lib/lambdas/getProductListLambda.ts",
+          handler: "handler",
+          runtime: Runtime.NODEJS_LATEST,
+          role: readLambdaRole,
+          environment: {
+            PRODUCT_TABLE: productTable.tableName,
+            STOCKS_TABLE: stockTable.tableName
+          }
+        }
+      )
+
+      const getProductsByIdLambda = new NodejsFunction(this, 'getProductsByIdLambda', {
+        entry: 'lib/lambdas/getProductByIdLambda.ts',
+        handler: 'handler',
         runtime: Runtime.NODEJS_LATEST,
         role: readLambdaRole,
         environment: {
           PRODUCT_TABLE: productTable.tableName,
           STOCKS_TABLE: stockTable.tableName
         }
-      }
-    )
+      });
 
-    const getProductsByIdLambda = new NodejsFunction(this, 'getProductsByIdLambda', {
-      entry: 'lib/lambdas/getProductByIdLambda.ts',
-      handler: 'handler',
-      runtime: Runtime.NODEJS_LATEST,
-      role: readLambdaRole,
-      environment: {
-        PRODUCT_TABLE: productTable.tableName,
-        STOCKS_TABLE: stockTable.tableName
-      }
-    });
+      const catalogBatchProcessLambda = new NodejsFunction(this, 'catalogBatchProcessLambda', {
+        entry: 'lib/lambdas/catalogBatchProcessLambda.ts',
+        handler: 'handler',
+        runtime: Runtime.NODEJS_LATEST,
+        role: writeLambdaRole,
+        bundling: {
+          minify: false,
+          externalModules: ['aws-cdk', 'uuid']
+        },
+        environment: {
+          PRODUCT_TABLE: productTable.tableName,
+          STOCKS_TABLE: stockTable.tableName,
+          CREATE_PRODUCT_TOPIC_ARN: createProductTopic.topicArn
+        },
+        layers: [uuidLayer]
+      })
+
+      catalogBatchProcessLambda.addEventSource(new SqsEventSource(catalogItemsQueue, {
+        batchSize: 5,
+      }))
+
+      createProductTopic.grantPublish(catalogBatchProcessLambda);
 
 
-    const api = new LambdaRestApi(this, 'ProductServiceApi', {
-      handler: getProductListLambda, 
-      proxy: false,
-      defaultCorsPreflightOptions: {
-        allowOrigins: Cors.ALL_ORIGINS
-      }
-    });
+      const api = new LambdaRestApi(this, 'ProductServiceApi', {
+        handler: getProductListLambda, 
+        proxy: false,
+        defaultCorsPreflightOptions: {
+          allowOrigins: Cors.ALL_ORIGINS
+        }
+      });
 
-    const products = api.root.addResource('products');
-    products.addMethod('GET', new LambdaIntegration(getProductListLambda));
-    products.addMethod('POST', new LambdaIntegration(createProductLambda));
+      const products = api.root.addResource('products');
+      products.addMethod('GET', new LambdaIntegration(getProductListLambda));
+      products.addMethod('POST', new LambdaIntegration(createProductLambda));
 
-    const productById = products.addResource('{productId}');
-    productById.addMethod('GET', new LambdaIntegration(getProductsByIdLambda));
-    
+      const productById = products.addResource('{productId}');
+      productById.addMethod('GET', new LambdaIntegration(getProductsByIdLambda));
+      
+    }
   }
-}

--- a/product_service/package-lock.json
+++ b/product_service/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.758.0",
+        "@aws-sdk/client-sns": "^3.758.0",
         "@aws-sdk/lib-dynamodb": "^3.758.0",
         "aws-cdk-lib": "2.178.2",
         "constructs": "^10.0.0",
@@ -282,6 +283,56 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns": {
+      "version": "3.758.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.758.0.tgz",
+      "integrity": "sha512-SyinKtqvp00w1YIfejqm5YsjicBe0GjnlaB5G7n45EPV4vKLfhzdJjVuEuwdRavdzOf99micK77NJbQX5S6TMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.758.0",
+        "@aws-sdk/credential-provider-node": "3.758.0",
+        "@aws-sdk/middleware-host-header": "3.734.0",
+        "@aws-sdk/middleware-logger": "3.734.0",
+        "@aws-sdk/middleware-recursion-detection": "3.734.0",
+        "@aws-sdk/middleware-user-agent": "3.758.0",
+        "@aws-sdk/region-config-resolver": "3.734.0",
+        "@aws-sdk/types": "3.734.0",
+        "@aws-sdk/util-endpoints": "3.743.0",
+        "@aws-sdk/util-user-agent-browser": "3.734.0",
+        "@aws-sdk/util-user-agent-node": "3.758.0",
+        "@smithy/config-resolver": "^4.0.1",
+        "@smithy/core": "^3.1.5",
+        "@smithy/fetch-http-handler": "^5.0.1",
+        "@smithy/hash-node": "^4.0.1",
+        "@smithy/invalid-dependency": "^4.0.1",
+        "@smithy/middleware-content-length": "^4.0.1",
+        "@smithy/middleware-endpoint": "^4.0.6",
+        "@smithy/middleware-retry": "^4.0.7",
+        "@smithy/middleware-serde": "^4.0.2",
+        "@smithy/middleware-stack": "^4.0.1",
+        "@smithy/node-config-provider": "^4.0.1",
+        "@smithy/node-http-handler": "^4.0.3",
+        "@smithy/protocol-http": "^5.0.1",
+        "@smithy/smithy-client": "^4.1.6",
+        "@smithy/types": "^4.1.0",
+        "@smithy/url-parser": "^4.0.1",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.7",
+        "@smithy/util-defaults-mode-node": "^4.0.7",
+        "@smithy/util-endpoints": "^3.0.1",
+        "@smithy/util-middleware": "^4.0.1",
+        "@smithy/util-retry": "^4.0.1",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso": {

--- a/product_service/package.json
+++ b/product_service/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.758.0",
+    "@aws-sdk/client-sns": "^3.758.0",
     "@aws-sdk/lib-dynamodb": "^3.758.0",
     "aws-cdk-lib": "2.178.2",
     "constructs": "^10.0.0",

--- a/product_service/test/catalogBatchProcessLambda.test.ts
+++ b/product_service/test/catalogBatchProcessLambda.test.ts
@@ -1,0 +1,148 @@
+import { handler } from "../lib/lambdas/catalogBatchProcessLambda";
+import { TransactWriteItemsCommand } from "@aws-sdk/client-dynamodb";
+import { marshall } from "@aws-sdk/util-dynamodb";
+
+jest.mock("/opt/nodejs/uuid-utils", () => ({
+  v4: jest.fn(() => "test-uuid"),
+}));
+
+
+const mockSend = jest.fn();
+
+
+jest.mock("@aws-sdk/lib-dynamodb", () => {
+  return {
+    DynamoDBDocumentClient: {
+      from: jest.fn(() => ({
+        send: mockSend,
+      })),
+    },
+  };
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.PRODUCT_TABLE = "test-products";
+  process.env.STOCKS_TABLE = "test-stocks";
+});
+
+describe("Lambda handler", () => {
+  it("should process a valid event with count provided", async () => {
+    mockSend.mockResolvedValueOnce({});
+    const event = {
+      Records: [
+        {
+          body: JSON.stringify({
+            title: "Test product",
+            description: "Test description",
+            price: "20",
+            count: "3",
+          }),
+        },
+      ],
+    };
+
+
+    await handler(event);
+
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const commandArg = mockSend.mock.calls[0][0];
+    expect(commandArg).toBeInstanceOf(TransactWriteItemsCommand);
+    expect(commandArg.input).toEqual({
+      TransactItems: [
+        {
+          Put: {
+            TableName: "test-products",
+            Item: marshall({
+              id: "test-uuid",
+              title: "Test product",
+              description: "Test description",
+              price: 20,
+            }),
+          },
+        },
+        {
+          Put: {
+            TableName: "test-stocks",
+            Item: marshall({
+              product_id: "test-uuid",
+              count: 3,
+            }),
+          },
+        },
+      ],
+    });
+  });
+
+  it("should default count to 0 when not provided", async () => {
+    // Arrange: simulate successful DynamoDB operation
+    mockSend.mockResolvedValueOnce({});
+    const event = {
+      Records: [
+        {
+          body: JSON.stringify({
+            title: "Test product 2",
+            description: "Test description 2",
+            price: "30",
+          }),
+        },
+      ],
+    };
+
+
+    await handler(event);
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const commandArg = mockSend.mock.calls[0][0];
+    expect(commandArg.input).toEqual({
+      TransactItems: [
+        {
+          Put: {
+            TableName: "test-products",
+            Item: marshall({
+              id: "test-uuid",
+              title: "Test product 2",
+              description: "Test description 2",
+              price: 30,
+            }),
+          },
+        },
+        {
+          Put: {
+            TableName: "test-stocks",
+            Item: marshall({
+              product_id: "test-uuid",
+              count: 0,
+            }),
+          },
+        },
+      ],
+    });
+  });
+
+  it("should handle errors during the DynamoDB operation", async () => {
+    const error = new Error("DynamoDB error");
+    mockSend.mockRejectedValueOnce(error);
+
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const event = {
+      Records: [
+        {
+          body: JSON.stringify({
+            title: "Test product",
+            description: "Test description",
+            price: "20",
+            count: "3",
+          }),
+        },
+      ],
+    };
+
+    await handler(event);
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Changelog
- added `catalogItemsQueue` SQS queue in stack
- implemented `catalogBatchProcessLambda` under Product Service triggered by SQS Event with batchSize configuration
- covered `catalogBatchProcess` with unit tests
- `catalogBatchProcessLambda` iterates over SQS events and adds them to the DynamoDB
- updated `importFileParserLambda` to send each CSV record to SQS and removed static logging into CloudWatch
- created `createProductTopic` SNS topic and email notifications triggered by successful import of products in `catalogBatchProcess`
- added filter policy to `createProductTopic` triggered when the price of the product is > 10000
- Integrated everything with Frontend Application (You can test it via link below. Just upload valid CSV and you should see them displayed on the landing page)



## Deployed Application
- https://d3pm995vl9dje7.cloudfront.net/
